### PR TITLE
Add text or Word to PDF converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # pydicom
+
+A simple repository containing a script to convert text or Word files to PDF.
+
+## Requirements
+
+Install dependencies using pip:
+
+```bash
+pip install fpdf python-docx
+```
+
+## Usage
+
+```
+python converter.py input.txt output.pdf
+python converter.py document.docx output.pdf
+```

--- a/converter.py
+++ b/converter.py
@@ -1,0 +1,50 @@
+import argparse
+import os
+from fpdf import FPDF
+from docx import Document
+
+
+def text_to_pdf(input_path: str, output_path: str) -> None:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.set_font("Arial", size=12)
+    with open(input_path, "r", encoding="utf-8") as f:
+        for line in f:
+            pdf.multi_cell(0, 10, line.rstrip())
+    pdf.output(output_path)
+
+
+def docx_to_pdf(input_path: str, output_path: str) -> None:
+    doc = Document(input_path)
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.set_font("Arial", size=12)
+    for para in doc.paragraphs:
+        text = para.text.strip()
+        if text:
+            pdf.multi_cell(0, 10, text)
+    pdf.output(output_path)
+
+
+def convert(input_path: str, output_path: str) -> None:
+    ext = os.path.splitext(input_path)[1].lower()
+    if ext in {".txt", ".text"}:
+        text_to_pdf(input_path, output_path)
+    elif ext == ".docx":
+        docx_to_pdf(input_path, output_path)
+    else:
+        raise ValueError("Unsupported input format: {}".format(ext))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert text or Word files to PDF")
+    parser.add_argument("input", help="Path to input .txt or .docx file")
+    parser.add_argument("output", help="Path to output .pdf file")
+    args = parser.parse_args()
+    convert(args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small `converter.py` script that converts `.txt` or `.docx` files to PDF
- document the dependencies and usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452403a3348327aa902274e2f3aee8